### PR TITLE
Initial version of polyline spanning multiple map layers

### DIFF
--- a/src/components/AppMap.ts
+++ b/src/components/AppMap.ts
@@ -165,11 +165,13 @@ class LayerProps {
   text: string;
   pathLength: number;
   order: number;
+  map_layer: string;
   constructor() {
     this.title = "";
     this.text = "";
     this.pathLength = 0;
     this.order = -1;
+    this.map_layer = "";
   }
   lengthAsString(): string {
     if (this.pathLength <= 0.0) {
@@ -185,6 +187,7 @@ class LayerProps {
     this.text = feat.properties.text || '';
     this.pathLength = feat.properties.pathLength || 0;
     this.order = (feat.properties.order !== undefined) ? feat.properties.order : -1;
+    this.map_layer = feat.properties.map_layer || 'Surface';
   }
 }
 function addGeoJSONFeatureToLayer(layer: any) {
@@ -230,6 +233,13 @@ function addPopupAndTooltip(layer: L.Marker | L.Polyline, root: any) {
         root.updateDrawLayerOpts({ txt: txt, layer });
       }
     });
+    popup.$on('map_layer', (txt: string) => {
+      if (layer && layer.feature) {
+        layer.feature.properties.map_layer = txt;
+        root.updateDrawLayerOpts({ map_layer: txt, layer });
+        root.updateDrawLayers();
+      }
+    });
     // Create Popup and Tooltip
     layerSetPopup(layer, popup);
     layer.bindTooltip(layer.feature.properties.tooltip());
@@ -265,6 +275,7 @@ export default class AppMap extends mixins(MixinUtil) {
   private drawLayerOpts: any[] = [];
   private drawLineColor = '#3388ff';
   private setLineColorThrottler!: () => void;
+  private markerVisibility: string = "opacity";
 
   private previousGotoMarker: L.Marker | null = null;
   private greatPlateauBarrierShown = false;
@@ -321,6 +332,9 @@ export default class AppMap extends mixins(MixinUtil) {
   // Replace current markers
   private importReplace: boolean = true;
 
+  // internal State for drawing markers
+  private drawVertexLayers: string[] = [];
+
   setViewFromRoute(route: any) {
     const x = parseFloat(route.params.x);
     const z = parseFloat(route.params.z);
@@ -362,7 +376,10 @@ export default class AppMap extends mixins(MixinUtil) {
     this.map.registerMoveEndCb(() => this.updateRoute());
     this.map.registerZoomEndCb(() => this.updateRoute());
     this.updateRoute();
-    this.map.registerBaseLayerChangeCb(() => this.updateMarkers());
+    this.map.registerBaseLayerChangeCb(() => {
+      this.updateMarkers();
+      this.updateDrawLayers();
+    });
   }
 
   initMarkers() {
@@ -529,6 +546,19 @@ export default class AppMap extends mixins(MixinUtil) {
     }
   }
 
+  updateDrawLayers() {
+    const activeLayer = this.map.activeLayer;
+    this.drawLayer.eachLayer((layer: any) => {
+      const alphas: { [key: string]: number } = { 'never': 0.0, always: 1.0, opacity: 0.3 }
+      const opacity = (layer.feature.properties.map_layer == activeLayer) ? 1.0 : alphas[this.markerVisibility];
+      if (ui.leafletType(layer) == ui.LeafletType.Marker) {
+        layer.setOpacity(opacity)
+      } else {
+        layer.setStyle({ opacity });
+      }
+    })
+  }
+
   changeLayerColor(event: any) {
     const id = Number(event.target.attributes.layer_id.value);
     const color = event.target.value;
@@ -561,6 +591,7 @@ export default class AppMap extends mixins(MixinUtil) {
         text: props.text,
         length: (ui.leafletType(layer) == ui.LeafletType.Marker) ? "" : props.pathLength.toFixed(2),
         visible: true,
+        map_layer: props.map_layer,
       };
     })
     // order values < 0 are appended at the end and given a value
@@ -589,6 +620,7 @@ export default class AppMap extends mixins(MixinUtil) {
         if (opt) {
           opt.title = updates.title || opt.title;
           opt.text = updates.text || opt.text;
+          opt.map_layer = updates.map_layer || opt.map_layer;
         }
       } else {
         this.drawLayerOpts = this.createDrawLayerOpts();
@@ -629,15 +661,64 @@ export default class AppMap extends mixins(MixinUtil) {
     this.map.m.on({
       // @ts-ignore
       'draw:created': (e: any) => {
-        addGeoJSONFeatureToLayer(e.layer);
-        calcLayerLength(e.layer);
-        addPopupAndTooltip(e.layer, this);
-        this.drawLayer.addLayer(e.layer);
-        this.initGeojsonFeature(e.layer);
-        if (!e.layer.options.color) {
-          e.layer.options.color = this.drawLineColor;
+        let group = [];
+        if (ui.leafletType(e.layer) == ui.LeafletType.Polyline) {
+          const map_layers = this.drawVertexLayers.filter((value, index, self) => { return self.indexOf(value) == index; });
+          if (map_layers.length != 1) {
+            const latlngs = e.layer.getLatLngs();
+            if (latlngs.length != this.drawVertexLayers.length) {
+              console.error("Mismatch between polyline vertex and drawVertexLayer lengths");
+              return;
+            }
+            let k = 0; // Last index in latlngs and drawVertexLayers
+            let p0 = undefined; // Last interpolation point
+            for (let i = 1; i < latlngs.length; i++) {
+              if (this.drawVertexLayers[i - 1] != this.drawVertexLayers[i]) {
+                // Points on different maps get split either in half or in thirds
+                if (this.drawVertexLayers[i - 1] != "Surface" && this.drawVertexLayers[i] != "Surface") {
+                  // Go from Sky <-> Depths, skipping the surface, divide into 3 parts
+                  const p1 = interp(latlngs[i - 1], latlngs[i], 1. / 3.);
+                  const p2 = interp(latlngs[i - 1], latlngs[i], 2. / 3.);
+                  const pts = (p0) ? [p0, ...latlngs.slice(k, i), p1] : [...latlngs.slice(k, i), p1];
+                  group.push({ layer: L.polyline(pts), map_layer: this.drawVertexLayers[k] });
+                  group.push({ layer: L.polyline([p1, p2]), map_layer: 'Surface' });
+                  p0 = p2;
+                } else {
+                  const pts = (p0) ? [p0, ...latlngs.slice(k, i)] : [...latlngs.slice(k, i)];
+                  p0 = interp(latlngs[i - 1], latlngs[i], 0.5);
+                  pts.push(p0);
+                  group.push({ layer: L.polyline(pts), map_layer: this.drawVertexLayers[k] });
+                }
+                k = i;
+              }
+            }
+            const pts = [p0, ...latlngs.slice(k)];
+            group.push({ layer: L.polyline(pts), map_layer: this.drawVertexLayers[k] });
+          } else {
+            group.push({ layer: e.layer, map_layer: this.drawVertexLayers[0] });
+          }
+        } else {
+          group.push({ layer: e.layer, map_layer: this.map.activeLayer });
         }
+        group.forEach((e: any) => {
+          addGeoJSONFeatureToLayer(e.layer);
+          calcLayerLength(e.layer);
+          e.layer.feature.properties.map_layer = e.map_layer;
+          addPopupAndTooltip(e.layer, this);
+          this.drawLayer.addLayer(e.layer);
+          this.initGeojsonFeature(e.layer);
+          if (!e.layer.options.color) {
+            e.layer.options.color = this.drawLineColor;
+          }
+        })
+        this.updateDrawLayers();
         this.updateDrawLayerOpts();
+      },
+      'draw:drawstart': () => {
+        this.drawVertexLayers = [];
+      },
+      'draw:drawvertex': () => {
+        this.drawVertexLayers.push(this.map.activeLayer);
       },
       'draw:edited': (e: any) => {
         e.layers.eachLayer((layer: L.Marker | L.Polyline) => {
@@ -665,6 +746,7 @@ export default class AppMap extends mixins(MixinUtil) {
     });
     this.updateDrawControlsVisibility();
     this.updateDrawLayerOpts();
+    this.updateDrawLayers();
   }
 
   private layerFromGeoJSON(feat: any): L.Layer {
@@ -758,6 +840,8 @@ export default class AppMap extends mixins(MixinUtil) {
             this.searchAddExcludedSet(g.query, g.label);
           });
         }
+        // Version 4 Add .map_layer = [Surface, Sky, Depths]
+        //   Handled by fromGeoJSON()
       }
     } catch (e) {
       alert(e);
@@ -1446,5 +1530,12 @@ export default class AppMap extends mixins(MixinUtil) {
     if (!this.updatingRoute)
       this.setViewFromRoute(to);
     next();
+  }
+}
+
+function interp(a: any, b: any, f: number) {
+  return {
+    lat: a.lat + f * (b.lat - a.lat),
+    lng: a.lng + f * (b.lng - a.lng),
   }
 }

--- a/src/components/AppMap.vue
+++ b/src/components/AppMap.vue
@@ -179,10 +179,20 @@
         <hr/>
         <div v-if="drawLayerOpts.length">
           <h4 class="subsection-heading">Polyline/Markers</h4>
+          <div class="marker-row">Items on another map:
+          <select v-model="markerVisibility" @change="updateDrawLayers" style="flex-grow: 2; margin-left: 1em">
+              <option value="never">Never show</option>
+              <option value="opacity">Less visible</option>
+              <option value="always">Always show</option>
+          </select>
+          </div>
           <draggable v-model="drawLayerOpts" @update="updateDrawLayerOptsIndex">
             <div v-for="layer in drawLayerOpts" :key="layer.id" @model="drawLayerOpts" class="marker-row" draggable="true">
               <div>
                 <input type="checkbox" @input="toggleLayerVisibility" :id="layer.id" :checked="layer.visible" >
+                <div v-if="layer.map_layer == 'Surface'" style="display: inline; padding-left: 0.3em;"> <i class="fa fa-tree fa-fw" style="color: lightgreen"></i></div>
+                <div v-else-if="layer.map_layer == 'Sky'"  style="display: inline; padding-left: 0.3em;"> <i class="fa fa-cloud fa-fw" style="color: lightblue"></i></div>
+                <div v-else-if="layer.map_layer == 'Depths'"  style="display: inline; padding-left: 0.3em;"><i class="fa fa-circle fa-fw" style="color: #D771DB;"></i></div>
                 <input type="color" :value="layer.color" @input="changeLayerColor" :layer_id="layer.id" class="marker-color">
                 <div class="inline-block">{{layer.title}}</div>
               </div>

--- a/src/components/AppMapPopup.ts
+++ b/src/components/AppMapPopup.ts
@@ -6,6 +6,7 @@ import Component from 'vue-class-component';
   props: {
     title: String,
     text: String,
+    map_layer: String,
     pathLength: Number,
   },
   watch: {
@@ -14,6 +15,9 @@ import Component from 'vue-class-component';
     },
     text: function(new_val: string, old_val: string) {
       this.$emit('text', new_val);
+    },
+    map_layer: function(new_val: string, old_val: string) {
+      this.$emit('map_layer', new_val);
     }
   },
 })

--- a/src/components/AppMapPopup.vue
+++ b/src/components/AppMapPopup.vue
@@ -2,6 +2,11 @@
   <div>
     <input class="w-100" placeholder="Title ..." v-model="title">
     <textarea class="w-100" placeholder="Description ..." v-model="text"></textarea>
+    <select v-model="map_layer">
+      <option>Sky</option>
+      <option>Surface</option>
+      <option>Depths</option>
+    </select>
     <div v-if="pathLength > 0">
       Length: {{pathLength.toFixed(2)}}
     </div>

--- a/src/save.ts
+++ b/src/save.ts
@@ -1,4 +1,4 @@
-export const CURRENT_OBJMAP_SV_VERSION = 3;
+export const CURRENT_OBJMAP_SV_VERSION = 4;
 
 export interface SearchGroup {
   label: string;


### PR DESCRIPTION
Addition of ability to Create and Edit markers and lines across multiple map layers.
If a polyline is created across multiple maps, it gets split into either 2 or 3 segments between the vertices that span the maps. 
Markers that are not on the current map can be 
- Never Shown
- Always Shown
- Show with a opacity of 0.3

Most of the additional code is within the splitting of the polylines.

Example polyline below was draw while also switching map layers.

![Screenshot 2023-06-15 at 17-16-02 TotK Object Map](https://github.com/zeldamods/objmap-totk/assets/126514/7c42632a-0ccd-4fc6-aea9-747d885349b0)
![Screenshot 2023-06-15 at 16-58-48 TotK Object Map](https://github.com/zeldamods/objmap-totk/assets/126514/6c50ec33-55f8-4032-96b6-d866c5192ac5)
![Screenshot 2023-06-15 at 17-16-10 TotK Object Map](https://github.com/zeldamods/objmap-totk/assets/126514/4f906b52-2cc6-4cdf-a1d8-ded266513295)
<img width="417" alt="Screen Shot 2023-06-15 at 7 18 00 PM" src="https://github.com/zeldamods/objmap-totk/assets/126514/b3618762-30f9-4d14-aacd-43eaab460f0c">

