### PR TITLE
Option to tell leaflet.draw to avoid touch screen behavior

### DIFF
--- a/src/components/AppMapSettings.vue
+++ b/src/components/AppMapSettings.vue
@@ -27,6 +27,12 @@
       </div>
       <b-btn class="mt-2" size="sm" @click="s.customSearchPresets.push(['', ''])"><i class="fa fa-plus"></i> Add</b-btn>
     </section>
+    <hr>
+    <h4 class="subsection-heading">Map Drawing</h4>
+    <b-checkbox switch v-model="s.noTouchScreen">Not using a touch screen</b-checkbox>
+    <p class="small">
+      Allows for clicking and dragging during line creation and markers are a more reasonable size. Reload the page for setting to take effect.
+    </p>
   </section>
 </template>
 <script src="./AppMapSettings.ts"></script>

--- a/src/util/settings.ts
+++ b/src/util/settings.ts
@@ -41,6 +41,7 @@ export class Settings {
   drawControlsShown!: boolean;
 
   decompBannerHidden!: boolean;
+  noTouchScreen!: boolean;
 
   private constructor() {
     this.load();
@@ -69,6 +70,7 @@ export class Settings {
     this.hylianMode = false;
     this.drawControlsShown = parse(data.drawControlsShown, Id, false);
     this.decompBannerHidden = parse(data.decompBannerHidden, Id, false);
+    this.noTouchScreen = parse(data.noTouchScreen, Id, false);
 
     this.invokeCallbacks();
   }
@@ -92,6 +94,7 @@ export class Settings {
       hylianMode: this.hylianMode,
       drawControlsShown: this.drawControlsShown,
       decompBannerHidden: this.decompBannerHidden,
+      noTouchScreen: this.noTouchScreen,
     };
     // Merge with existing data to avoid data loss.
     const existingDataStr = localStorage.getItem(Settings.KEY);


### PR DESCRIPTION
Option added on Settings pane and in settings `noTouchScreen`
- Fixes clicking and dragging the map on polyline creation
- Modifies icon size on polyline creation and editing to be a reasonable size
   - Default is 8x8, touch icon is 20x20; this uses 12x12
- Patch overrides the `_noTouch()` function in Leaflet.Draw Polyline

There has been numerous discussions regarding Leaflet.Draw and its use of `click` events and attempting to use the presence of touch event to determine if a touch screen in present.  

See:
TouchExtend brakes map dragging (Leaflet.Draw)
https://github.com/Leaflet/Leaflet.draw/issues/935#issue-446986829
 L.Browser.touch should be retired (Leaflet)
https://github.com/Leaflet/Leaflet/issues/6978#issue-554006348