### PR TITLE
Make chasms visible in the Depths

### DIFF
--- a/src/MapMarker.ts
+++ b/src/MapMarker.ts
@@ -355,6 +355,9 @@ export class MapMarkerCave extends MapMarkerGenericLocationMarker {
     if (this.mb.activeLayer == 'Surface' && y < 1000 && y > -50) {
       return true;
     }
+    if (this.mb.activeLayer == 'Depths' && this.info.Icon == 'Chasm') {
+      return true;
+    }
     return false;
   }
 }


### PR DESCRIPTION
This is a PR to resolve #57. It makes chasms visible on the map when viewing the Depths layer, but only when the Chasm filter is enabled.

To accomplish this, it inspects `MapMarkerCave`'s `info.Icon` property instead of its `info.Translate.Y` position. This is to avoid making caves and wells show up in the Depths. Please let me know if there is a better way to accomplish this.