### PR TITLE
Add Layer to Route

### DIFF
--- a/src/components/AppMap.ts
+++ b/src/components/AppMap.ts
@@ -348,6 +348,9 @@ export default class AppMap extends mixins(MixinUtil) {
       zoom = 3;
 
     this.map.setView([x, 0, z], zoom);
+    const layer = route.params.layer;
+    if (layer && ["Surface", "Depths", "Sky"].includes(layer))
+      this.map.switchBaseTileLayer(layer);
   }
   updateRoute() {
     this.updatingRoute = true;
@@ -358,6 +361,7 @@ export default class AppMap extends mixins(MixinUtil) {
         x: this.map.center[0],
         z: this.map.center[2],
         zoom: this.map.m.getZoom(),
+        layer: this.map.activeLayer,
       },
       query: this.$route.query,
     }).catch(err => {

--- a/src/components/AppMap.ts
+++ b/src/components/AppMap.ts
@@ -383,6 +383,7 @@ export default class AppMap extends mixins(MixinUtil) {
     this.map.registerBaseLayerChangeCb(() => {
       this.updateMarkers();
       this.updateDrawLayers();
+      this.updateRoute();
     });
   }
 

--- a/src/router.ts
+++ b/src/router.ts
@@ -10,6 +10,11 @@ export default new Router({
   routes: [
     { path: '/map', redirect: '/map/zx,0,0' },
     {
+      path: '/map/z:zoom,:x,:z,:layer',
+      name: 'map',
+      component: AppMap,
+    },
+    {
       path: '/map/z:zoom,:x,:z',
       name: 'map',
       component: AppMap,


### PR DESCRIPTION
Add activeLayer to the Route

Allows for bringing up the current layer from the url

Minor change, but might break something else.

Checked: All named layers, incorrectly named layers, and queries
These all appear to work as expected.